### PR TITLE
Add cron schedule for R CMD CHECK

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  schedule:
+    - cron: '0 0 * * 0' # every Sunday at midnight
 
 name: R-CMD-check.yaml
 


### PR DESCRIPTION
This PR adds a schedule (once a week, every Sunday), to the `R CMD CHECK` workflow. This way, I can catch problems that might arise with newer versions of R. 